### PR TITLE
:wrench: Terraform version bump and alias removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.terraform*

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,6 @@ locals {
 }
 
 provider "aws" {
-  alias  = "useast1"
   region = "us-east-1"
 }
 
@@ -15,7 +14,6 @@ resource "aws_acm_certificate" "cert" {
   domain_name       = local.policydomain
   validation_method = "DNS"
   tags              = var.tags
-  provider          = aws.useast1
 }
 
 data "aws_route53_zone" "zone" {
@@ -33,7 +31,6 @@ resource "aws_route53_record" "cert_validation" {
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn         = aws_acm_certificate.cert.arn
   validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
-  provider                = aws.useast1
 }
 
 resource "aws_s3_bucket" "policybucket" {
@@ -161,3 +158,4 @@ resource "aws_route53_record" "mtastspolicydns" {
     "v=STSv1; id=${local.policyhash}",
   ]
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
The alias is pointless here and the Terraform version bump matches with our sts caller.
